### PR TITLE
feat: support running hugo serve from container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:latest
+ARG UID=1000
+ARG GID=1000
+RUN apk add --no-cache inotify-tools
+RUN apk add --no-cache hugo 
+RUN apk add --no-cache ruby
+VOLUME [ "/data" ]
+USER $UID:$GID
+ENV HUGO_ARGS="--bind=0.0.0.0"
+WORKDIR /data

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+## How to run slides
+
+### Linux
+
+```bash
+./shared-slides/serve.sh
+```
+
+### Other
+
+```bash
+UID=`id -u` GID=`id -g` docker compose up --build
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  hugo:
+    build: 
+      context: .
+      tags:
+        - hugo-slides-server
+      args:
+        UID: ${UID}
+        GID: ${GID}
+    volumes:
+      - .:/data
+    ports:
+      - 1313:1313
+    command: sh /data/shared-slides/serve.sh


### PR DESCRIPTION
Here's a way to run inotifywait-enabled hugo serve from any os, via docker

__Note__: requires this edit to `shared-slides`: https://github.com/DanySK/shared-slides/pull/328